### PR TITLE
Update to publish replication agent transportUri to  host

### DIFF
--- a/AEM/Dockerfile-AEM-author
+++ b/AEM/Dockerfile-AEM-author
@@ -4,10 +4,12 @@ FROM aem-base:latest
 
 ENV CQ_RUNMODE author
 ENV CQ_PORT 4502
+ENV PUBLISH_HOST publish
 
 RUN echo sling.run.modes=${CQ_RUNMODE} >> crx-quickstart/conf/sling.properties && \
     crx-quickstart/bin/start && \
     until $(curl -u admin:admin --output /dev/null --silent --head --fail http://localhost:$CQ_PORT); do printf '.'; sleep 5; done && \
+    curl http://localhost:4502/etc/replication/agents.author/publish/jcr:content -F transportUri=http://${PUBLISH_HOST}:4503/bin/receive?sling:authRequestLogin=1 -uadmin:admin && \
     crx-quickstart/bin/stop
 
 EXPOSE $CQ_PORT

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ Execute within the project root folder
 docker-compose up
 ```
 
-## Known Issues
-- The default replication agent isn't configured correctly. The hostname _localhost_ has to be replaced by _publish_.
-
 ## Access AEM Environment
 When you want to access you environment on Windows or MAC, you have to resolve the IP of your Boot2Docker VM first:
 ```boot2docker ip```


### PR DESCRIPTION
I've added a step to the author setup script that updates the transport URI for the publish replication agent to be `http://publish:4503/...`.  The value comes from the `PUBLISH_HOST` environment variable, so could be overridden at during build.
